### PR TITLE
Add resizable frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+## [v3.3.0] - 2026-07-10
+
+Added:
+
+- Frame resizing
+
 ## [v3.2.0] - 2026-07-07
 
 Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Added:
 - Refactored main content script that manages frame creation and navigation to be a Vue 3 app
 - Refactored frame serialisation to use indexed parameters
 
+Fixed:
+
+- Workflowy / Multiflow navigation frame swapping bug
+
 ## [v3.1.0] - 2026-07-05
 
 Added:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "workflowy-multiflow",
   "description": "Multi-column view for WorkFlowy",
+  "version": "3.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/composables/useWindowSize.ts
+++ b/src/composables/useWindowSize.ts
@@ -1,0 +1,22 @@
+import { onMounted, onUnmounted, ref } from 'vue'
+
+/**
+ * Reactive window inner size, updated on resize.
+ *
+ * Listeners are added on mount and removed on unmount, so it is safe to use in
+ * any component; the refs seed from the current window immediately.
+ */
+export function useWindowSize () {
+  const width = ref(window.innerWidth)
+  const height = ref(window.innerHeight)
+
+  function update () {
+    width.value = window.innerWidth
+    height.value = window.innerHeight
+  }
+
+  onMounted(() => window.addEventListener('resize', update))
+  onUnmounted(() => window.removeEventListener('resize', update))
+
+  return { width, height }
+}

--- a/src/entrypoints/content/components/App.vue
+++ b/src/entrypoints/content/components/App.vue
@@ -1,17 +1,147 @@
 <template>
-  <main :style="{ width }">
-    <Frame v-for="frame in state.frames" :key="frame.id" :frame="frame" />
+  <main ref="main" :class="{ dragging }">
+    <!--
+      One frame element per state.frames entry, keyed by id and NEVER reordered
+      or spliced (except on true removal) — an iframe reloads only when its DOM
+      node moves. Visual order + width + visibility are all applied via inline
+      style, so a frame stays mounted and alive across show / hide / reorder.
+    -->
+    <Frame
+      v-for="frame in state.frames"
+      :key="frame.id"
+      :frame="frame"
+      :data-frame-id="frame.id"
+      :style="frameStyle(frame)"
+    />
+
+    <!-- draggable splitters between adjacent visible columns -->
+    <div
+      v-for="splitter in splitters"
+      :key="`splitter-${splitter.leftId}`"
+      class="splitter"
+      :style="{ order: splitter.order }"
+      @mousedown.prevent="onDragStart($event, splitter)"
+    />
   </main>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { WF_WIDTH } from '../helpers/url'
-import { state, visibleFrames } from '../services/frame'
+import { computed, ref } from 'vue'
+import { MIN_PANE_WIDTH, setWidths, state, visibleFrames, widths } from '../services/frame'
+import type { FrameState } from '../services/frame'
+import type { Width } from '@utils/session'
 import Frame from './Frame.vue'
 
-// hug layout sizes the container to its frames; other layouts fill the viewport
-const width = computed(() => state.layout === 'hug'
-  ? (WF_WIDTH * visibleFrames.value.length) + 'px'
-  : 'auto')
+const main = ref<HTMLElement>()
+
+// ---------------------------------------------------------------------------------------------------------------------
+// layout
+// ---------------------------------------------------------------------------------------------------------------------
+
+// map each visible frame's id to its width spec (indexed by visual order)
+const widthMap = computed(() => {
+  const map = new Map<number, Width>()
+  visibleFrames.value.forEach((frame, index) => map.set(frame.id, widths.value[index]))
+  return map
+})
+
+/**
+ * Per-frame flex style. Frame DOM order is fixed, so visual position comes from
+ * CSS `order`; doubling it leaves the odd values free for splitters to slot
+ * between neighbours. Hidden frames stay mounted via display:none.
+ */
+function frameStyle (frame: FrameState) {
+  const order = frame.order * 2
+  if (!frame.visible) {
+    return { order, display: 'none' }
+  }
+  const width = widthMap.value.get(frame.id)
+  return {
+    order,
+    flex: width === '*' || width == null ? '1 1 0' : `0 0 ${width}px`,
+  }
+}
+
+interface Splitter {
+  leftId: number
+  rightId: number
+  order: number
+}
+
+// a splitter between each pair of adjacent visible columns; its CSS order sits
+// on the odd value between the two frames' (doubled) orders
+const splitters = computed<Splitter[]>(() => {
+  const frames = visibleFrames.value
+  const out: Splitter[] = []
+  for (let i = 0; i < frames.length - 1; i++) {
+    out.push({ leftId: frames[i].id, rightId: frames[i + 1].id, order: frames[i].order * 2 + 1 })
+  }
+  return out
+})
+
+// ---------------------------------------------------------------------------------------------------------------------
+// drag
+// ---------------------------------------------------------------------------------------------------------------------
+
+const dragging = ref(false)
+
+// snapshot captured on mousedown; measured pixel widths of every visible column
+let drag: { startX: number, leftIndex: number, widthsPx: number[] } | null = null
+
+function onDragStart (event: MouseEvent, splitter: Splitter) {
+  const frames = visibleFrames.value
+  const leftIndex = frames.findIndex(frame => frame.id === splitter.leftId)
+  if (leftIndex < 0) {
+    return
+  }
+  // measure real pixels for every column, so a flexing `*` column becomes a
+  // concrete width we can steal from / hand to its neighbour
+  const widthsPx = frames.map(frame => frameEl(frame.id)?.getBoundingClientRect().width ?? 0)
+  drag = { startX: event.clientX, leftIndex, widthsPx }
+  dragging.value = true
+  window.addEventListener('mousemove', onDragMove)
+  window.addEventListener('mouseup', onDragEnd)
+}
+
+function onDragMove (event: MouseEvent) {
+  if (!drag) {
+    return
+  }
+
+  // steal-from-neighbour: the two adjacent columns trade pixels, their sum held
+  const { leftIndex, widthsPx } = drag
+  const startLeft = widthsPx[leftIndex]
+  const startRight = widthsPx[leftIndex + 1]
+  const total = startLeft + startRight
+  let left = startLeft + (event.clientX - drag.startX)
+  let right = total - left
+
+  // clamp so neither adjacent column drops below the minimum
+  if (left < MIN_PANE_WIDTH) {
+    left = MIN_PANE_WIDTH
+    right = total - left
+  }
+  else if (right < MIN_PANE_WIDTH) {
+    right = MIN_PANE_WIDTH
+    left = total - right
+  }
+
+  // emit a custom spec: every column fixed at its (updated) px except the last,
+  // which flexes to absorb the remainder — fixed-left, flexible-last
+  const spec: Width[] = widthsPx.map((width, index) =>
+    Math.round(index === leftIndex ? left : index === leftIndex + 1 ? right : width))
+  spec[spec.length - 1] = '*'
+  setWidths(spec)
+}
+
+function onDragEnd () {
+  drag = null
+  dragging.value = false
+  window.removeEventListener('mousemove', onDragMove)
+  window.removeEventListener('mouseup', onDragEnd)
+}
+
+function frameEl (id: number): HTMLIFrameElement | null | undefined {
+  return main.value?.querySelector<HTMLIFrameElement>(`iframe[data-frame-id="${id}"]`)
+}
 </script>

--- a/src/entrypoints/content/components/App.vue
+++ b/src/entrypoints/content/components/App.vue
@@ -14,20 +14,21 @@
       :style="frameStyle(frame)"
     />
 
-    <!-- draggable splitters between adjacent visible columns -->
+    <!-- draggable splitters between adjacent visible columns; double-click to even out -->
     <div
       v-for="splitter in splitters"
       :key="`splitter-${splitter.leftId}`"
       class="splitter"
       :style="{ order: splitter.order }"
       @mousedown.prevent="onDragStart($event, splitter)"
+      @dblclick.prevent="onReset"
     />
   </main>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { MIN_PANE_WIDTH, setWidths, state, visibleFrames, widths } from '../services/frame'
+import { MIN_PANE_WIDTH, setLayout, setWidths, state, visibleFrames, widths } from '../services/frame'
 import type { FrameState } from '../services/frame'
 import type { Width } from '@utils/session'
 import Frame from './Frame.vue'
@@ -108,30 +109,52 @@ function onDragMove (event: MouseEvent) {
     return
   }
 
-  // steal-from-neighbour: the two adjacent columns trade pixels, their sum held
+  // recompute from the drag-start snapshot each move, so the result is a pure
+  // function of the total delta (deterministic + reversible mid-drag)
   const { leftIndex, widthsPx } = drag
-  const startLeft = widthsPx[leftIndex]
-  const startRight = widthsPx[leftIndex + 1]
-  const total = startLeft + startRight
-  let left = startLeft + (event.clientX - drag.startX)
-  let right = total - left
+  const delta = event.clientX - drag.startX
+  const result = [...widthsPx]
+  const last = result.length - 1
 
-  // clamp so neither adjacent column drops below the minimum
-  if (left < MIN_PANE_WIDTH) {
-    left = MIN_PANE_WIDTH
-    right = total - left
+  if (delta > 0) {
+    // grow the left column, pushing the following columns nearest-first; each
+    // gives up space down to the minimum before the push cascades to the next
+    let remaining = delta
+    for (let j = leftIndex + 1; j <= last && remaining > 0; j++) {
+      const take = Math.min(remaining, widthsPx[j] - MIN_PANE_WIDTH)
+      if (take > 0) {
+        result[j] = widthsPx[j] - take
+        remaining -= take
+      }
+    }
+    result[leftIndex] = widthsPx[leftIndex] + (delta - remaining)
   }
-  else if (right < MIN_PANE_WIDTH) {
-    right = MIN_PANE_WIDTH
-    left = total - right
+  else if (delta < 0) {
+    // shrink the left column, pulling from the earlier columns nearest-first;
+    // each gives up space down to the minimum before the pull cascades to the
+    // previous one. The freed space is handed to the immediate follower
+    let remaining = -delta
+    for (let j = leftIndex; j >= 0 && remaining > 0; j--) {
+      const take = Math.min(remaining, widthsPx[j] - MIN_PANE_WIDTH)
+      if (take > 0) {
+        result[j] = widthsPx[j] - take
+        remaining -= take
+      }
+    }
+    result[leftIndex + 1] = widthsPx[leftIndex + 1] + (-delta - remaining)
   }
 
   // emit a custom spec: every column fixed at its (updated) px except the last,
   // which flexes to absorb the remainder — fixed-left, flexible-last
-  const spec: Width[] = widthsPx.map((width, index) =>
-    Math.round(index === leftIndex ? left : index === leftIndex + 1 ? right : width))
-  spec[spec.length - 1] = '*'
+  const spec: Width[] = result.map(width => Math.round(width))
+  spec[last] = '*'
   setWidths(spec)
+}
+
+// even the columns back out — the fill preset is exactly-equal flex, and drops
+// the custom widths from the URL / session
+function onReset () {
+  setLayout('fill')
 }
 
 function onDragEnd () {

--- a/src/entrypoints/content/components/Frame.vue
+++ b/src/entrypoints/content/components/Frame.vue
@@ -1,5 +1,6 @@
 <template>
-  <iframe ref="el" :class="{ hidden: !frame.visible }" :style="{ order: frame.order }" />
+  <!-- bare iframe; App.vue owns order / width / visibility via fall-through style -->
+  <iframe ref="el" />
 </template>
 
 <script setup lang="ts">

--- a/src/entrypoints/content/components/Frame.vue
+++ b/src/entrypoints/content/components/Frame.vue
@@ -66,16 +66,30 @@ function onReady () {
   store.onFrameFocused(props.frame.id)
 
   // close button
-  const button = doc.createElement('div')
   const header = doc.body.querySelector('.header')
   if (header) {
-    header.appendChild(button)
-    button.style.marginLeft = '-10px'
-    button.style.marginRight = '10px'
-    button.innerHTML = '<div class="iconButton _pn8v4l"><svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke-linecap="round" stroke="#b7bcbf" style="position: relative;"><line x1="1" y1="1" x2="19" y2="19"></line><line x1="19" y1="1" x2="1" y2="19"></line></svg></div>'
+    const button = doc.createElement('div')
+    button.className = 'relative outline-none menu'
+    Object.assign(button.style, {
+      position: 'absolute',
+      right: '8px',
+      top: '56px'
+    })
+    button.innerHTML = `<div>
+                          <div
+                            class="iconButton lg shape-circle"
+                            data-style="box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);"
+                          >
+                            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                              <path d="M1.46973 1.46973C1.76262 1.17683 2.23738 1.17683 2.53028 1.46973L12.5303 11.4697C12.8232 11.7626 12.8232 12.2374 12.5303 12.5303C12.2374 12.8232 11.7626 12.8232 11.4697 12.5303L1.46973 2.53027C1.17684 2.23738 1.17684 1.76262 1.46973 1.46973Z" />
+                              <path d="M11.4697 1.46973C11.7626 1.17683 12.2374 1.17683 12.5303 1.46973C12.8232 1.76262 12.8232 2.23738 12.5303 2.53027L2.53028 12.5303C2.23738 12.8232 1.76262 12.8232 1.46973 12.5303C1.17684 12.2374 1.17684 11.7626 1.46973 11.4697L11.4697 1.46973Z" />
+                            </svg>
+                          </div>
+                        </div>`
     button.addEventListener('click', (event) => {
       store.closeFrame(props.frame.id, isModifier(event))
     })
+    header.appendChild(button)
   }
 }
 

--- a/src/entrypoints/content/content.scss
+++ b/src/entrypoints/content/content.scss
@@ -69,10 +69,26 @@ body {
   }
 
   .splitter {
-    flex: 0 0 5px;
+    // visually a 1px line; the wider grab area is the ::before overlay below
+    flex: 0 0 1px;
     height: 100%;
-    cursor: col-resize;
+    position: relative;
     background: #DDD;
+    // sit above the iframes so the grab overlay catches the cursor over them
+    z-index: 2;
+
+    // grab area: extends over the neighbouring frames without taking layout space.
+    // biased to the right so it clears the left frame's native scrollbar, which
+    // sits just to the left of the splitter
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: -1px;
+      right: -6px;
+      cursor: col-resize;
+    }
 
     &:hover {
       background: #BBB;

--- a/src/entrypoints/content/content.scss
+++ b/src/entrypoints/content/content.scss
@@ -23,22 +23,6 @@ body {
     }
   }
 
-  &[data-layout="hug"] {
-    overflow-x: scroll;
-  }
-
-  &[data-layout="hug"] iframe {
-    min-width: 700px !important;
-  }
-
-  &[data-layout="nav"] iframe:first-child {
-    max-width: 450px;
-  }
-
-  &[data-frames="1"] iframe {
-    max-width: unset !important;
-  }
-
   &[data-message] .message {
 
   }
@@ -53,19 +37,46 @@ body {
 
   main {
     display: flex;
+    width: 100%;
     height: 100%;
+
+    // fixed columns (hug, or dragged widths wider than the viewport) overflow;
+    // a `*` column always fits, so no scrollbar appears for fill / nav
+    overflow-x: auto;
+
+    // iframes swallow mouse events, so a drag started on a splitter is lost the
+    // moment the cursor crosses a frame. While dragging, disable frame pointer
+    // events (and text selection) so the drag survives until mouseup.
+    &.dragging {
+      cursor: col-resize;
+      user-select: none;
+
+      iframe {
+        pointer-events: none;
+      }
+    }
   }
 
   iframe {
-    flex: 1;
+    // flex (fixed px or `*`) is applied inline by App.vue; min-width is the hard
+    // floor — see MIN_PANE_WIDTH: below ~470px WorkFlowy's own UI starts clipping
+    flex: 1 1 0;
+    min-width: 470px;
     margin: 0;
     height: 100%;
     border: none;
     outline: 1px solid #DDD;
   }
 
-  .hidden {
-    display: none;
+  .splitter {
+    flex: 0 0 5px;
+    height: 100%;
+    cursor: col-resize;
+    background: #DDD;
+
+    &:hover {
+      background: #BBB;
+    }
   }
 }
 

--- a/src/entrypoints/content/helpers/url.ts
+++ b/src/entrypoints/content/helpers/url.ts
@@ -1,5 +1,5 @@
 import { parseRoute } from '@utils/url'
-import { decodeSession, encodeSession, FRAMES, LAYOUT } from '../services/session'
+import { decodeSession, encodeSession, FRAMES, LAYOUT, WIDTHS } from '../services/session'
 import type { Session } from '@utils/session'
 
 /**
@@ -16,10 +16,11 @@ const ORIGIN = window.location.origin
  */
 export function parseRootUrl (asUrls = false) {
   const { search } = parseRoute(location.href)
-  const { hashes, layout } = decodeSession(search)
+  const { hashes, layout, widths } = decodeSession(search)
   return {
     urls: hashes.map(hash => asUrls ? `${ORIGIN}/#${hash}` : hash),
     layout,
+    widths,
   }
 }
 
@@ -46,7 +47,7 @@ export function cleanRootUrl () {
   // clean frame params
   const params = new URLSearchParams(search)
   Array.from(params.keys()).forEach((key) => {
-    if (key === FRAMES || key === LAYOUT) {
+    if (key === FRAMES || key === LAYOUT || key === WIDTHS) {
       params.delete(key)
     }
   })

--- a/src/entrypoints/content/helpers/url.ts
+++ b/src/entrypoints/content/helpers/url.ts
@@ -44,10 +44,11 @@ export function cleanRootUrl () {
   // get query
   const { origin, id, search } = parseRoute(location.href)
 
-  // clean frame params
+  // clean frame params (indexed f1, f2, … plus legacy f, and layout / widths)
   const params = new URLSearchParams(search)
+  const rxFrame = new RegExp(`^${FRAMES}\\d+$`)
   Array.from(params.keys()).forEach((key) => {
-    if (key === FRAMES || key === LAYOUT || key === WIDTHS) {
+    if (rxFrame.test(key) || key === FRAMES || key === LAYOUT || key === WIDTHS) {
       params.delete(key)
     }
   })

--- a/src/entrypoints/content/index.ts
+++ b/src/entrypoints/content/index.ts
@@ -75,14 +75,14 @@ export default defineContentScript({
       setTimeout(() => store.openUrls(urls, false), 100)
     }
 
-    // otherwise, wait for workflowy to load
-    else {
-      void runWhen(
-        () => document.getElementById('loadingScreen')?.style.display === 'none',
-        () => runWhen(checkReady(document), onReady),
-        250,
-      )
-    }
+    // always wait for workflowy's own app to be ready, so root-page click
+    // handling (used once back in single-page mode) is registered even when
+    // the tab boots straight into a multiflow url
+    void runWhen(
+      () => document.getElementById('loadingScreen')?.style.display === 'none',
+      () => runWhen(checkReady(document), onReady),
+      250,
+    )
 
     /**
      * Note that MultiFlow doesn't even load if WorkFlowy's "Open links in desktop app"

--- a/src/entrypoints/content/index.ts
+++ b/src/entrypoints/content/index.ts
@@ -24,7 +24,7 @@ export default defineContentScript({
     }
 
     // parse url before WF gets a chance to modify it
-    const { urls, layout } = parseRootUrl(true)
+    const { urls, layout, widths } = parseRootUrl(true)
 
     // mount the app; inert (display: none) until frames are added
     // createIntegratedUi wires ctx so WXT can invalidate and re-inject without a full page reload
@@ -65,7 +65,11 @@ export default defineContentScript({
     // if we have URLs, immediately load frames
     if (urls.length > 1) {
       log('loading frames')
-      if (layout) {
+      // widths (custom layout) take precedence; setWidths implies layout = custom
+      if (widths) {
+        store.setWidths(widths)
+      }
+      else if (layout) {
         store.setLayout(layout)
       }
       setTimeout(() => store.openUrls(urls, false), 100)

--- a/src/entrypoints/content/services/frame.ts
+++ b/src/entrypoints/content/services/frame.ts
@@ -265,11 +265,24 @@ export function closeFrame (id: number, remove = false): void {
     }
   }
 
-  // otherwise, exit multiflow to the remaining frame
+  // otherwise, exit multiflow to the remaining frame: hide (or remove) both
+  // frames first, so `mode` flips to 'workflowy' — this hides the multiflow
+  // div via CSS, and stops the session watcher from re-pushing the multiflow
+  // url over the navigation below. Hiding rather than removing keeps both
+  // iframes mounted, so re-entering multiflow reuses them instead of reloading
   else {
     const other = visibleFrames.value.find(frame => frame.id !== id)
     if (other) {
       const url = registry.get(other.id)?.().url ?? other.url
+      if (remove) {
+        state.frames.splice(state.frames.indexOf(frame), 1)
+        state.frames.splice(state.frames.indexOf(other), 1)
+        normalizeOrders()
+      }
+      else {
+        hideFrame(frame)
+        hideFrame(other)
+      }
       window.location.href = makeWfUrl(url, ORIGIN)
     }
   }

--- a/src/entrypoints/content/services/frame.ts
+++ b/src/entrypoints/content/services/frame.ts
@@ -3,8 +3,8 @@ import { log } from '@utils/app'
 import { getHash, makeWfUrl } from '@utils/url'
 import { setSetting as setBodySetting } from '../helpers/dom'
 import { buildSession } from './session'
-import { cleanRootUrl } from '../helpers/url'
-import type { Layout, Session } from '@utils/session'
+import { cleanRootUrl, WF_WIDTH } from '../helpers/url'
+import type { Layout, Session, Width } from '@utils/session'
 
 /**
  * Live data read from a frame's window
@@ -42,6 +42,24 @@ let seq = 0
 const ORIGIN = window.location.origin
 
 // ---------------------------------------------------------------------------------------------------------------------
+// widths
+// ---------------------------------------------------------------------------------------------------------------------
+
+/**
+ * Narrowest a column may ever get, in px.
+ *
+ * ~470px is the point below which WorkFlowy's own UI starts clipping / hiding
+ * chrome, so no column should shrink past it. Enforced twice: as CSS
+ * `min-width` on each column, and as a clamp while dragging a splitter.
+ */
+export const MIN_PANE_WIDTH = 470
+
+// default fixed width of the `nav` sidebar column; a real px so it doesn't
+// balloon with the viewport. Pinned to the floor above (a nav below the min
+// would clip WorkFlowy's chrome).
+export const NAV_WIDTH = MIN_PANE_WIDTH
+
+// ---------------------------------------------------------------------------------------------------------------------
 // state
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -51,6 +69,11 @@ export const state = reactive({
   frames: [] as FrameState[],
 
   layout: 'fill' as Layout,
+
+  // per-visible-column widths for the `custom` layout, indexed by visual order;
+  // exactly one entry is '*' (the last, by default authoring). Only meaningful
+  // while layout === 'custom'; presets derive their widths from defaultWidths()
+  customWidths: [] as Width[],
 
   // focused frame id (0 = none); an id survives the array splices that closeFrame does, an index would not
   focused: 0,
@@ -63,6 +86,53 @@ export const state = reactive({
 const ordered = computed(() => [...state.frames].sort((a, b) => a.order - b.order))
 
 export const visibleFrames = computed(() => ordered.value.filter(frame => frame.visible))
+
+/**
+ * The effective width spec for the current layout + visible column count.
+ *
+ * Each layout is just a pattern over the one pixel/`*` model: `fill` is all
+ * flexible, `nav` pins a fixed sidebar, `hug` is all fixed (and scrolls), and
+ * `custom` carries the user's dragged widths.
+ */
+export const widths = computed<Width[]>(() => defaultWidths(state.layout, visibleFrames.value.length))
+
+export function defaultWidths (layout: Layout, n: number): Width[] {
+  if (n <= 0) {
+    return []
+  }
+  switch (layout) {
+    // all fixed at a full WorkFlowy width; the container scrolls horizontally
+    case 'hug':
+      return Array(n).fill(WF_WIDTH)
+
+    // fixed sidebar, everything else flexes
+    case 'nav':
+      return n === 1 ? ['*'] : [NAV_WIDTH, ...Array(n - 1).fill('*')]
+
+    // the user's dragged widths, refit if a frame was added / removed since
+    case 'custom':
+      return state.customWidths.length === n ? [...state.customWidths] : fitWidths(state.customWidths, n)
+
+    // even split: every column flexes
+    case 'fill':
+    default:
+      return Array(n).fill('*')
+  }
+}
+
+/**
+ * Refit a stored custom spec to a new column count (a frame was opened / closed
+ * while in custom layout): keep leading fixed widths, drop / pad to length, and
+ * force the last column flexible per the fixed-left / flexible-last rule.
+ */
+function fitWidths (spec: Width[], n: number): Width[] {
+  const out = spec.slice(0, n)
+  while (out.length < n) {
+    out.push('*')
+  }
+  out[out.length - 1] = '*'
+  return out
+}
 
 // position of the focused frame in the iframe DOM order (creation order); the interop
 // API's data-focused contract. Derived live so it stays valid after frames are removed
@@ -79,7 +149,19 @@ export const session = computed<Session>(() => buildSession(visibleFrames.value.
   url: frame.url,
   hash: getHash(frame.url),
   title: frame.title,
-})), { layout: state.layout }, ORIGIN))
+})), currentSettings(), ORIGIN))
+
+/**
+ * The persisted settings for the current layout. Widths are only carried for
+ * `custom`; every preset's widths are derivable from its name + column count.
+ */
+function currentSettings (): Session['settings'] {
+  const settings: Session['settings'] = { layout: state.layout }
+  if (state.layout === 'custom') {
+    settings.widths = widths.value
+  }
+  return settings
+}
 
 /**
  * Live frame data accessors, registered by mounted Frame components
@@ -109,7 +191,7 @@ export function getSession (): Session {
   if (frames.length === 0) {
     frames.push(getRootData())
   }
-  return buildSession(frames, { layout: state.layout }, ORIGIN)
+  return buildSession(frames, currentSettings(), ORIGIN)
 }
 
 function getRootData (): FrameData {
@@ -197,10 +279,21 @@ export function setLayout (layout: Layout): void {
   state.layout = layout
 }
 
+/**
+ * Adopt an explicit set of column widths; this is what a splitter drag or a
+ * restored `s=` produces, so it always means the layout is now `custom`.
+ */
+export function setWidths (widths: Width[]): void {
+  state.customWidths = widths
+  state.layout = 'custom'
+}
+
 export function setSetting (key: string, value: any): void {
   key === 'layout'
     ? setLayout(value)
-    : setBodySetting(key, value)
+    : key === 'widths'
+      ? setWidths(value)
+      : setBodySetting(key, value)
 }
 
 export function applySession (session: Session): void {

--- a/src/entrypoints/content/services/session.ts
+++ b/src/entrypoints/content/services/session.ts
@@ -1,5 +1,5 @@
 import { getHash, makeWfUrl } from '@utils/url'
-import type { Layout, Session } from '@utils/session'
+import type { Layout, Session, Width } from '@utils/session'
 
 /**
  * Session logic for the content page: building a Session from live frames and
@@ -25,6 +25,7 @@ export interface FrameLike {
 // MultiFlow URL param names (the serialisation contract)
 export const FRAMES = 'f'
 export const LAYOUT = 'l'
+export const WIDTHS = 's'
 
 // ---------------------------------------------------------------------------------------------------------------------
 // session <-> url serialisation
@@ -47,7 +48,9 @@ function tryDecode (value: string) {
  *
  * One indexed param per frame; URLSearchParams encodes each hash correctly,
  * including hashes carrying a search query (#/abc?q=foo). Layout is only added
- * when it is meaningful (multiple frames, non-default value).
+ * when it is meaningful (multiple frames, non-default value). Widths are only
+ * added for `custom` (presets derive their own), appended raw so the commas
+ * stay unescaped, e.g. `s=460,1000,*`.
  */
 export function encodeSession (session: Session): string {
   const { urls, settings } = session
@@ -56,7 +59,11 @@ export function encodeSession (session: Session): string {
   if (settings.layout && settings.layout !== 'fill' && urls.length > 1) {
     params.set(LAYOUT, settings.layout)
   }
-  return params.toString()
+  let query = params.toString()
+  if (settings.layout === 'custom' && Array.isArray(settings.widths) && urls.length > 1) {
+    query += `&${WIDTHS}=${(settings.widths as Width[]).join(',')}`
+  }
+  return query
 }
 
 /**
@@ -67,7 +74,7 @@ export function encodeSession (session: Session): string {
  *
  * https://workflowy.com/#?f1=fa901479206c&f2=ed7149b5e538&l=nav
  */
-export function decodeSession (search: string): { hashes: string[], layout?: Layout } {
+export function decodeSession (search: string): { hashes: string[], layout?: Layout, widths?: Width[] } {
   const params = new URLSearchParams(search)
   const rxFrame = new RegExp(`^${FRAMES}\\d+$`)
 
@@ -86,10 +93,29 @@ export function decodeSession (search: string): { hashes: string[], layout?: Lay
       .map(tryDecode)
   }
 
+  // widths imply the custom layout; a present `s=` wins over the `l=` token
+  const widths = decodeWidths(params.get(WIDTHS))
+
   return {
     hashes,
-    layout: (params.get(LAYOUT) as Layout) || undefined,
+    layout: widths ? 'custom' : (params.get(LAYOUT) as Layout) || undefined,
+    widths,
   }
+}
+
+/**
+ * Parse an `s=460,1000,*` widths param into `[460, 1000, '*']`, dropping any
+ * malformed entries. Returns undefined when absent or empty.
+ */
+function decodeWidths (raw: string | null): Width[] | undefined {
+  if (!raw) {
+    return undefined
+  }
+  const widths = raw
+    .split(',')
+    .map(token => token === '*' ? '*' : parseInt(token, 10))
+    .filter((width): width is Width => width === '*' || (typeof width === 'number' && !isNaN(width)))
+  return widths.length ? widths : undefined
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/src/entrypoints/content/services/sync.ts
+++ b/src/entrypoints/content/services/sync.ts
@@ -2,7 +2,7 @@ import { watch } from 'vue'
 import { type Bus } from 'bus'
 import { setSetting } from '../helpers/dom'
 import { makeRootUrl, parseRootUrl } from '../helpers/url'
-import { focusedIndex, loading, mode, openUrls, session, setLayout, state, visibleFrames } from './frame'
+import { focusedIndex, loading, mode, openUrls, session, setLayout, setWidths, state, visibleFrames } from './frame'
 
 /**
  * Central store side effects: body data-* attributes (the interop and CSS
@@ -71,11 +71,13 @@ function syncSession (): void {
  * Sync frames when the user navigates back / forward
  */
 function onPopState (): void {
-  const { urls, layout } = parseRootUrl(true)
+  const { urls, layout, widths } = parseRootUrl(true)
 
   // multiflow url; diff-load frames without touching history
   if (urls.length > 1) {
-    setLayout(layout || 'fill')
+    widths
+      ? setWidths(widths)
+      : setLayout(layout || 'fill')
     openUrls(urls, false)
   }
 

--- a/src/entrypoints/popup/popup.vue
+++ b/src/entrypoints/popup/popup.vue
@@ -220,7 +220,6 @@ async function getData () {
     }
     if (data.session.urls.length === 1) {
       session.value.settings.layout = 'fill'
-      void setSetting('layout', 'fill')
     }
   }
   else {

--- a/src/entrypoints/popup/popup.vue
+++ b/src/entrypoints/popup/popup.vue
@@ -153,7 +153,7 @@ const options = {
     fill: 'Fill',
     hug: 'Hug',
     nav: 'Nav',
-    // custom: 'Custom'
+    custom: 'Custom'
   } as Record<Layout, string>,
 }
 

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,7 +1,10 @@
 import { Storage } from '@utils/storage'
 
-export type Layout = 'hug' | 'fill' | 'nav' // | 'custom'
+export type Layout = 'hug' | 'fill' | 'nav' | 'custom'
 export type Setting = 'layout' | string
+
+// a column width: an explicit pixel value, or '*' to flex and fill the remaining viewport
+export type Width = number | '*'
 
 export interface Session {
   id: string

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'wxt'
+import pkg from './package.json'
 
 function toArray<T> (value: T | T[]): T[] {
   return Array.isArray(value)
@@ -30,7 +31,7 @@ export default defineConfig({
   manifest: {
     name: 'WorkFlowy MultiFlow',
     description : "Multi-column view for WorkFlowy",
-    version: '3.2.0',
+    version: pkg.version,
     // @ts-ignore
     key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoWDu35r1oWfV8YVlJbXNOpqL3lhgO4wgyb7dfAcl6trIfwsQSg2W3EERJDbN3LzhYEmvszbrQlot+scVpK9WM94HbXag8IBEIiIh24WmX6xlv5PT3j2ibccXiJ9x/sCaP2MGRzPNkkO1hJjBIup6ogn3/U3ynbQ6lqdtYI9Ju0IWSNXIt493Ch/dvD1cjxPzLLcCcrU9O50evAm/gFknFiPla6UKqU6ApkUpnwO3L3emphEXtKcK1I/VfzCFDJ/7PUnOKVBiLwbQWZjSfhdLtdzdwovGgklr4XmicpEL//k5HO9zTjXd8eEL6Yo0ik1Kk/Skm9226B9rQnL6Od9WgwIDAQAB',
     permissions: [


### PR DESCRIPTION
## Overview

This PR adds resizeable frames.

Featuring:

- serialisation to URL & session
- cascading resizing to preceding or following siblings
- double-click frame borders to equalise
- minimum frame width to prevent UI collapse (could be made optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom pane layouts with draggable frame resizing.
  * Added support for preserving custom pane widths in shared and restored sessions.
  * Enabled the custom layout option in the layout controls.
  * Improved responsive behavior as the browser window changes size.

* **Bug Fixes**
  * Fixed navigation issues when swapping or closing Workflowy and Multiflow frames.
  * Improved loading and restoration of multi-frame sessions.

* **Documentation**
  * Added release notes for version 3.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->